### PR TITLE
fix: harden Safe Browsing transport handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -88,3 +88,4 @@ e) to display the Original Work publicly.
 15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
 
 This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved. Permission is hereby granted to copy and distribute this license without modification. This license may not be modified without the express written permission of its copyright owner.
+

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: Safe Browsing
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Safe Browsing
 
-Publisher: Splunk \
-Connector Version: 2.0.8 \
-Product Vendor: Google \
-Product Name: Safe Browsing \
+Publisher: Splunk <br>
+Connector Version: 2.0.8 <br>
+Product Vendor: Google <br>
+Product Name: Safe Browsing <br>
 Minimum Product Version: 5.1.0
 
 This app Integrate with Google Safe Browsing to execute reputation-based actions
@@ -18,15 +18,15 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Checks API Key with Google Safe Browsing \
-[url reputation](#action-url-reputation) - Determine the reputation of a URL \
+[test connectivity](#action-test-connectivity) - Checks API Key with Google Safe Browsing <br>
+[url reputation](#action-url-reputation) - Determine the reputation of a URL <br>
 [domain reputation](#action-domain-reputation) - Determine the reputation of a domain
 
 ## action: 'test connectivity'
 
 Checks API Key with Google Safe Browsing
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -41,7 +41,7 @@ No Output
 
 Determine the reputation of a URL
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Checks with Google Safe Browsing for records of a URL's previous malicious behavior.
@@ -72,7 +72,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Determine the reputation of a domain
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Checks with Google Safe Browsing for records of a domain's previous malicious behavior.
@@ -103,7 +103,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: refresh development checks (temporary baseline note).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: refresh development checks (temporary baseline note).
+* Enabled TLS certificate verification for Google Safe Browsing API requests. (PAPP-38040)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Enabled TLS certificate verification for Google Safe Browsing API requests. (PAPP-38040)
+* Prevented API credentials from appearing in transport failure messages. (PAPP-38040)

--- a/safebrowsing.json
+++ b/safebrowsing.json
@@ -5,7 +5,7 @@
     "publisher": "Splunk",
     "package_name": "phantom_safebrowsing",
     "type": "information",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "main_module": "safebrowsing_connector.py",
     "app_version": "2.0.8",
     "utctime_updated": "2025-08-01T20:38:12.501972Z",

--- a/safebrowsing_connector.py
+++ b/safebrowsing_connector.py
@@ -57,7 +57,10 @@ class SafeBrowsingConnector(BaseConnector):
             resp_json = response.json()
 
         except Exception as e:
-            return action_result.set_status(phantom.APP_ERROR, SAFEBROWSING_ERR_SERVER_CONNECTION, e)
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"{SAFEBROWSING_ERR_SERVER_CONNECTION}: {type(e).__name__}",
+            )
 
         action_result.add_data(resp_json)
 

--- a/safebrowsing_connector.py
+++ b/safebrowsing_connector.py
@@ -52,7 +52,7 @@ class SafeBrowsingConnector(BaseConnector):
         params = {"key": self._api_key}
 
         try:
-            response = method(self._base_url + endpoint, data=body, params=params, verify=False)
+            response = method(self._base_url + endpoint, data=body, params=params, verify=True)
 
             resp_json = response.json()
 

--- a/safebrowsing_connector.py
+++ b/safebrowsing_connector.py
@@ -1,6 +1,6 @@
 # File: safebrowsing_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/safebrowsing_consts.py
+++ b/safebrowsing_consts.py
@@ -1,6 +1,6 @@
 # File: safebrowsing_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Bug Fixes

- Enable TLS certificate verification for all Google Safe Browsing API requests (PSAAS-30618 / VULN-93343 / FS-1134).
- Keep raw transport exception text out of action results so request URLs and API keys cannot be disclosed (PSAAS-31011 / VULN-93736 / FS-1844; PSAAS-31250 / VULN-93975 / FS-2114).

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate; these internal transport-hardening changes do not require manual documentation changes.

### Other information

- Tracking: PAPP-38040; parent epic ESPM-5228.
- Validation: full `pre-commit run --all-files` passed, including Docker-backed dependency packaging and static tests; Python compilation, JSON parsing, and diff checks also passed.
- Patch review: the credential-disclosure patches proposed either redacting raw exception strings or returning only the exception class. This implementation uses only the exception class because partial URL redaction can miss alternate exception formats.
- Breaking changes: none.

Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
